### PR TITLE
feat: add magic link email template with OTP support

### DIFF
--- a/.claude.md
+++ b/.claude.md
@@ -1,0 +1,24 @@
+# Claude Configuration
+
+## Project: Bowers Backend
+
+This is a Supabase backend project for the BellSkill application.
+
+## Code Style Guidelines
+
+- All files should end with a newline
+- Follow existing code conventions in the project
+- Use TypeScript for type safety
+- Follow Supabase best practices for database operations
+
+## Commit Message Guidelines
+
+- Use conventional commit format (feat:, fix:, etc.)
+- Keep messages concise and descriptive
+- Do not include Claude attribution in commit messages
+
+## Testing
+
+- Run tests before committing changes
+- Check for lint and type errors
+- Ensure all migrations are properly tested

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,6 +149,11 @@ otp_expiry = 3600
 # subject = "You have been invited"
 # content_path = "./supabase/templates/invite.html"
 
+# Magic link email template with OTP support
+[auth.email.template.magic_link]
+subject = "Sign in to BellSkill"
+content_path = "./supabase/templates/magic_link.html"
+
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.
 enable_signup = false

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Sign in to BellSkill</title>
+</head>
+<body>
+    <h2>Sign in to BellSkill</h2>
+    <p>Click this link to sign in: <a href="{{ .ConfirmationURL }}">Sign In</a></p>
+    <p>Or enter this 6-digit code: <strong>{{ .Token }}</strong></p>
+</body>
+</html>


### PR DESCRIPTION
Configure Supabase email template to include both confirmation URL and OTP token for flexible authentication options. Add Claude configuration file for project-specific settings.